### PR TITLE
Fix Netlify deployment 'Page not found' error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
   },
   root: path.resolve(import.meta.dirname, "client"),
   build: {
-    outDir: path.resolve(import.meta.dirname, "dist/public"),
+    outDir: path.resolve(import.meta.dirname, "dist"),
     emptyOutDir: true,
   },
   server: {


### PR DESCRIPTION
This change configures the project for a static site deployment on Netlify to resolve the 404 "Page not found" error.

The key changes are:
- A `netlify.toml` file is added to configure Netlify's build settings and to add a redirect rule (`/* -> /index.html`) to support single-page application (SPA) routing.
- `vite.config.ts` is updated to change the build output directory to `dist`, aligning with the Netlify configuration.
- The `build` script in `package.json` is simplified to `vite build`, removing the unnecessary server-side build for static deployment.